### PR TITLE
Fix Bug

### DIFF
--- a/unity-ads/src/main/java/com/unity3d/services/core/request/metrics/MetricSender.java
+++ b/unity-ads/src/main/java/com/unity3d/services/core/request/metrics/MetricSender.java
@@ -76,7 +76,7 @@ public class MetricSender extends MetricSenderBase {
 			return;
 		}
 
-		_executorService.submit(new Runnable() {
+		_executorService.execute(new Runnable() {
 			@Override
 			public void run() {
 				try {

--- a/unity-ads/src/main/java/com/unity3d/services/core/webview/bridge/invocation/WebViewBridgeInvocation.java
+++ b/unity-ads/src/main/java/com/unity3d/services/core/webview/bridge/invocation/WebViewBridgeInvocation.java
@@ -23,7 +23,7 @@ public class WebViewBridgeInvocation implements IWebViewBridgeInvocation {
 
 	@Override
 	public synchronized void invoke(final String className, final String methodName, final int timeoutLengthInMilliSeconds, final Object... invocationParameters) {
-		_executorService.submit(
+		_executorService.execute(
 			new WebViewBridgeInvocationRunnable(invocationCallback, _webViewBridgeInvoker, className, methodName, timeoutLengthInMilliSeconds, invocationParameters));
 	}
 }


### PR DESCRIPTION
1。The callback of onUnityAdsFailedToLoad and onUnityAdsShowFailure should be dispatched in main thread。 
2。Fix the exception escape caused by using ExecutorService.submit。
When using ExecutorService.submit, if it is not handled properly, it may cause an exception to escape. For example: only call the method, but do not handle its exception

The following is the official document introduction：https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html
> Note: When actions are enclosed in tasks (such as FutureTask) either explicitly or via methods such as submit, these task objects catch and maintain computational exceptions, and so they do not cause abrupt termination, and the internal exceptions are not passed to this method.