### PR TITLE
Update AdUnitActivity.java to remove back press Bug in newer android devices

### DIFF
--- a/unity-ads/src/main/java/com/unity3d/services/ads/adunit/AdUnitActivity.java
+++ b/unity-ads/src/main/java/com/unity3d/services/ads/adunit/AdUnitActivity.java
@@ -83,6 +83,11 @@ public class AdUnitActivity extends Activity implements IAdUnitActivity {
 
 	@Override
 	public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            if ((applicationContext as Application).isAdShowing()) {
+                return true // Disable back press
+            }
+        }
 		return _controller.onKeyDown(keyCode, event);
 	}
 


### PR DESCRIPTION
Users are currently able to press back button while watching ads. This creates a bug where both skip ad button and back press button create the same ad completion key that is SKIPPED. but in case of back press user did not skip the ad rather he/she didn't watch the ad even a little bit. This creates a problem for the developers to identify which is which. Please either approve this PR or provide an alternative solution. Thanks.